### PR TITLE
Permit empty yaml

### DIFF
--- a/lib/global_settings/yml_settings.rb
+++ b/lib/global_settings/yml_settings.rb
@@ -16,9 +16,8 @@ module GlobalSettings
     end
 
     def to_hash
-      YAML.load.tap do |yaml|
-        return {} if not yaml
-      end.deep_symbolize_keys!
+      hash = YAML.load_file(yml_settings_path)
+      hash ? hash.deep_symbolize_keys! : {}
      rescue Errno::ENOENT
        puts "Could not load settings from settings.yml file for #{@environment} environment"
        {}

--- a/lib/global_settings/yml_settings.rb
+++ b/lib/global_settings/yml_settings.rb
@@ -16,7 +16,9 @@ module GlobalSettings
     end
 
     def to_hash
-      YAML.load_file(yml_settings_path).deep_symbolize_keys!
+      YAML.load.tap do |yaml|
+        return {} if not yaml
+      end.deep_symbolize_keys!
      rescue Errno::ENOENT
        puts "Could not load settings from settings.yml file for #{@environment} environment"
        {}


### PR DESCRIPTION
@rodrei please review this fix,
instead of returning 'false' when YAML file is empty, we can return '{}'.
